### PR TITLE
Extends `ignores` with support for glob-style pattern matching

### DIFF
--- a/lib/utils/library.js
+++ b/lib/utils/library.js
@@ -1,4 +1,5 @@
 var _ = require('lodash'),
+	multimatch = require('multimatch'),
 	generateShortname = require('./generate-shortname');
 
 /**
@@ -46,7 +47,7 @@ function Library(ignores) {
 			if (!dontCount) {
 				_library[name].hits++;
 			}
-		} else if (_ignores.indexOf(name) === -1) {
+		} else if (!multimatch(name, _ignores).length) {
 			shortname = generateShortname(size);
 			_library[name] = {
 				shortname: shortname,

--- a/package.json
+++ b/package.json
@@ -7,10 +7,11 @@
     "email": "calebthebrewer@gmail.com"
   },
   "dependencies": {
+    "event-stream": "~3.1.7",
     "gulp-util": "~3.0.1",
-    "through2": ">=0.6.1 <1.0.0-0",
     "lodash": "~2.4.1",
-    "event-stream": "~3.1.7"
+    "multimatch": "^1.0.1",
+    "through2": ">=0.6.1 <1.0.0-0"
   },
   "homepage": "https://github.com/calebthebrewer/gulp-selectors",
   "bugs": "https://github.com/calebthebrewer/gulp-selectors/issues",


### PR DESCRIPTION
### Advanced `ignores` Usage

``` js
var ignores: {
    classes: ['is-*', 'state-*', 'js-*']
};

gs.run({}, ignores);
```
